### PR TITLE
Add support for query parameters

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@
 const { send, createError } = require('micro');
 const RadixRouter = require('radix-router');
 const assert = require('assert');
+const url = require('url');
 
 const routerSymbol = Symbol();
 
@@ -147,7 +148,8 @@ module.exports = exports = class Router {
      * @param {object} res http.serverResponse
      */
     async handle(req, res) {
-        const route = this[routerSymbol].lookup(req.url);
+        const { pathname } = url.parse(req.url);
+        const route = this[routerSymbol].lookup(pathname);
 
         if (route && req.method.toLowerCase() in route.methods) {
             try {


### PR DESCRIPTION
Currently, if you have a URL such as `/?hello=world`, the router says that the route is not found. I made changes so that it ignores all query params and matches only the route itself (`/`).